### PR TITLE
Fix of `:configure` and implementation of client and  `:lambda_function_list` methods.

### DIFF
--- a/lib/shrine/plugins/lambda.rb
+++ b/lib/shrine/plugins/lambda.rb
@@ -5,19 +5,18 @@ require 'aws-sdk-lambda'
 class Shrine
   module Plugins
     module Lambda
-      # Required AWS credentials:
-      SETTINGS = { access_key_id: :required, region: :required, callback_url: :optional,
-                   secret_access_key: :required }
+      SETTINGS = { access_key_id: :required, callback_url: :optional, region: :required,
+                   secret_access_key: :required }.freeze
 
       Error = Class.new(Shrine::Error)
 
       # If promoting was not yet overridden, it is set to automatically trigger
       # Lambda processing defined in `Shrine#lambda_process`.
       def self.configure(uploader, settings = {})
-        settings.each do |option|
-          uploader.opts[option] = settings.fetch(option, uploader.opts[option])
-          if SETTINGS[option] == :required && uploader.opts[option].nil?
-            raise Error, "The :#{option} is required for Lambda plugin"
+        SETTINGS.each_key do |key, value|
+          uploader.opts[key] = settings.fetch(key, uploader.opts[key])
+          if value == :required && uploader.opts[key].nil?
+            raise Error, "The :#{key} is required for Lambda plugin"
           end
         end
 
@@ -28,6 +27,36 @@ class Shrine
       # It loads the backgrounding plugin, so that it can override promoting.
       def self.load_dependencies(uploader, _opts = {})
         uploader.plugin :backgrounding
+      end
+
+      module ClassMethods
+        # Creates a new AWS Lambda client
+        def lambda
+          Aws::Lambda::Client.new(access_key_id:     opts[:access_key_id],
+                                  secret_access_key: opts[:secret_access_key],
+                                  region:            opts[:region])
+        end
+
+        def lambda_function_list()
+          opts[:lambda_function_list] = lambda.list_functions(# master_region: s3_options[:region],
+                                                              function_version: 'ALL', # accepts ALL
+                                                              # marker: 'String',
+                                                              max_items: 100)
+        end
+      end
+
+      module InstanceMethods
+        # A cached instance of an AWS Lambda client.
+        def lambda
+          @lambda ||= self.class.lambda
+        end
+
+        def lambda_function_list(force: false)
+          fl = self.opts[:lambda_function_list]
+          return fl unless force || fl.nil? || fl.empty?
+          self.class.lambda_function_list
+          self.opts[:lambda_function_list]
+        end
       end
     end
 

--- a/lib/shrine/plugins/lambda.rb
+++ b/lib/shrine/plugins/lambda.rb
@@ -15,9 +15,7 @@ class Shrine
       def self.configure(uploader, settings = {})
         SETTINGS.each_key do |key, value|
           uploader.opts[key] = settings.fetch(key, uploader.opts[key])
-          if value == :required && uploader.opts[key].nil?
-            raise Error, "The :#{key} is required for Lambda plugin"
-          end
+          raise Error, "The :#{key} is required for Lambda plugin" if value == :required && uploader.opts[key].nil?
         end
 
         # TODO: Check this - seems it have to be a requirement, not an option
@@ -31,17 +29,28 @@ class Shrine
 
       module ClassMethods
         # Creates a new AWS Lambda client
-        def lambda
-          Aws::Lambda::Client.new(access_key_id:     opts[:access_key_id],
-                                  secret_access_key: opts[:secret_access_key],
-                                  region:            opts[:region])
+        # @param (see Aws::Lambda::Client#initialize)
+        def lambda(access_key_id:     opts[:access_key_id],
+                   secret_access_key: opts[:secret_access_key],
+                   region:            opts[:region], **args)
+
+          Aws::Lambda::Client.new(args.merge!(access_key_id:     access_key_id,
+                                              secret_access_key: secret_access_key,
+                                              region:            region))
         end
 
-        def lambda_function_list()
-          opts[:lambda_function_list] = lambda.list_functions(# master_region: s3_options[:region],
-                                                              function_version: 'ALL', # accepts ALL
-                                                              # marker: 'String',
-                                                              max_items: 100)
+        # Memoize and returns a list of your Lambda functions. For each function, the
+        # response includes the function configuration information.
+        #
+        # @param (see Aws::Lambda::Client#list_functions)
+        # @param force [Boolean] reloading the list via request to AWS if true
+        def lambda_function_list(master_region: nil, function_version: 'ALL', marker: nil, items: 100, force: false)
+          fl = opts[:lambda_function_list]
+          return fl unless force || fl.nil? || fl.empty?
+          opts[:lambda_function_list] = lambda.list_functions(master_region: master_region,
+                                                              function_version: function_version,
+                                                              marker: marker,
+                                                              max_items: items)
         end
       end
 
@@ -52,10 +61,9 @@ class Shrine
         end
 
         def lambda_function_list(force: false)
-          fl = self.opts[:lambda_function_list]
+          fl = opts[:lambda_function_list]
           return fl unless force || fl.nil? || fl.empty?
-          self.class.lambda_function_list
-          self.opts[:lambda_function_list]
+          self.class.lambda_function_list(force: force)
         end
       end
     end

--- a/shrine-lambda.gemspec
+++ b/shrine-lambda.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
 
   gem.add_dependency 'aws-sdk-lambda', '~> 1.0'
+  gem.add_dependency 'aws-sdk-s3', '~> 1.2'
   gem.add_dependency 'shrine', '~> 2.6'
 
-  gem.add_development_dependency 'aws-sdk-s3', '~> 1.2'
   gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'minitest-hooks'


### PR DESCRIPTION
Fixed Lambda plugin configuration method to iterate through all the settings.

Implemented class and instance `:lambda` and  `:lambda_function_list` methods for client initialization-invocation and function list retrieval. Function list is memoized into the `Shrine.opts` hash.

`Shrine.lambda_function_list` could be put into Shrine initializer to load the list on application start.
